### PR TITLE
Fuzz: fix NoMemory behavior

### DIFF
--- a/src/ext/_ppmdmodule.c
+++ b/src/ext/_ppmdmodule.c
@@ -915,8 +915,7 @@ Ppmd7Encoder_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         }
         Py_XDECREF(self);
     }
-    PyErr_NoMemory();
-    return NULL;
+    return PyErr_NoMemory();
 }
 
 static void
@@ -949,6 +948,8 @@ Ppmd7Encoder_init(Ppmd7Encoder *self, PyObject *args, PyObject *kwargs)
     static char *kwlist[] = {"max_order", "mem_size", NULL};
     PyObject *max_order = Py_None;
     PyObject *mem_size = Py_None;
+
+    ACQUIRE_LOCK(self);
     if (!PyArg_ParseTupleAndKeywords(args, kwargs,
                                      "OO:Ppmd7Encoder.__init__", kwlist,
                                      &max_order, &mem_size)) {
@@ -999,12 +1000,15 @@ Ppmd7Encoder_init(Ppmd7Encoder *self, PyObject *args, PyObject *kwargs)
             }
         }
         PyMem_Free(self->cPpmd7);
+        PyErr_NoMemory();
     }
 
 error:
+    RELEASE_LOCK(self);
     return -1;
 
 success:
+    RELEASE_LOCK(self);
     return 0;
 }
 
@@ -1131,7 +1135,6 @@ Ppmd8Decoder_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     Ppmd8Decoder *self;
     self = (Ppmd8Decoder*)type->tp_alloc(type, 0);
     if (self == NULL) {
-        PyErr_NoMemory();
         goto error;
     }
     assert(self->inited == 0);
@@ -1140,14 +1143,13 @@ Ppmd8Decoder_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     /* Thread lock */
     self->lock = PyThread_allocate_lock();
     if (self->lock == NULL) {
-        PyErr_NoMemory();
         goto error;
     }
     return (PyObject*)self;
 
 error:
     Py_XDECREF(self);
-    return NULL;
+    return PyErr_NoMemory();
 }
 
 static void
@@ -1181,6 +1183,8 @@ Ppmd8Decoder_init(Ppmd8Decoder *self, PyObject *args, PyObject *kwargs)
     static char *kwlist[] = {"max_order", "mem_size", NULL};
     PyObject *max_order = Py_None;
     PyObject *mem_size = Py_None;
+
+    ACQUIRE_LOCK(self);
     if (!PyArg_ParseTupleAndKeywords(args, kwargs,
                                      "OO:Ppmd8Decoder.__init__", kwlist,
                                      &max_order, &mem_size)) {
@@ -1228,12 +1232,15 @@ Ppmd8Decoder_init(Ppmd8Decoder *self, PyObject *args, PyObject *kwargs)
             goto success;
         }
         PyMem_Free(self->cPpmd8);
+        PyErr_NoMemory();
     }
 
 error:
+    RELEASE_LOCK(self);
     return -1;
 
 success:
+    RELEASE_LOCK(self);
     return 0;
 }
 

--- a/src/ext/_ppmdmodule.c
+++ b/src/ext/_ppmdmodule.c
@@ -1578,7 +1578,7 @@ Ppmd8Encoder_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     } else {
         PyErr_SetString(PyExc_RuntimeError, "Ppmd8Encoder_new error(no memory)");
     }
-    PyErr_NoMemory();
+    //return PyErr_NoMemory();
     return NULL;
 }
 

--- a/src/ext/_ppmdmodule.c
+++ b/src/ext/_ppmdmodule.c
@@ -1573,7 +1573,10 @@ Ppmd8Encoder_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         if ((self->lock = PyThread_allocate_lock()) != NULL) {
             return (PyObject*)self;
         }
+        PyErr_SetString(PyExc_RuntimeError, "Ppmd8Encoder_new error(lock error)");
         Py_XDECREF(self);
+    } else {
+        PyErr_SetString(PyExc_RuntimeError, "Ppmd8Encoder_new error(no memory)");
     }
     PyErr_NoMemory();
     return NULL;

--- a/tests/test_fuzzer.py
+++ b/tests/test_fuzzer.py
@@ -1,7 +1,6 @@
 import sys
 
 import psutil
-import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 

--- a/tests/test_fuzzer.py
+++ b/tests/test_fuzzer.py
@@ -11,7 +11,6 @@ vmem = psutil.virtual_memory()
 MAX_SIZE = min(0xFFFFFFFF - 12 * 3, sys.maxsize, vmem.available)
 
 
-@pytest.mark.skipif(sys.platform.startswith("win"), reason="hypothesis test on windows fails with unknown reason.")
 @given(
     obj=st.binary(min_size=1),
     max_order=st.integers(min_value=2, max_value=64),
@@ -28,7 +27,6 @@ def test_ppmd7_fuzzer(obj, max_order, mem_size):
     assert result == obj
 
 
-@pytest.mark.skipif(sys.platform.startswith("win"), reason="hypothesis test on windows fails with unknown reason.")
 @given(
     obj=st.binary(min_size=1),
     max_order=st.integers(min_value=2, max_value=64),

--- a/tests/test_fuzzer.py
+++ b/tests/test_fuzzer.py
@@ -7,7 +7,7 @@ from hypothesis import strategies as st
 import pyppmd
 
 vmem = psutil.virtual_memory()
-MAX_SIZE = min(0xFFFFFFFF - 12 * 3, sys.maxsize, vmem.available)
+MAX_SIZE = min(0xFFFFFFFF - 12 * 3, sys.maxsize, vmem.available >> 2)
 
 
 @given(


### PR DESCRIPTION
- Fix to `return PyErr_NoMemory()`
- reduce fuzzing memory range