### PR TITLE
Fix MANIFEST not include .github and .egg-info

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -86,7 +86,7 @@ jobs:
         uses: actions/setup-python@v2
       - name: Build source distribution & wheels
         run: |
-          python setup.py sdist --formats=gztar
+          python setup.py sdist --formats=gztar --egg-base /tmp
           python -m pip install -U pip
           python -m pip install -U cibuildwheel
           python -m cibuildwheel --output-dir wheelhouse

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -24,5 +24,9 @@ recursive-include tests *.py
 recursive-include utils *.py
 recursive-include utils *.txt
 
+exclude .gitignore
+exclude .gitattributes
 recursive-exclude * __pycache__
-recursive-exclude * *.pyc
+recursive-exclude *.pyc
+recursive-exclude .github *.yml
+recursive-exclude .github *.md

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -17,8 +17,6 @@ recursive-include src py.typed
 recursive-include src *.c
 
 recursive-include tests *.csv
-recursive-include tests *.dat
-recursive-include tests *.ppmd
 recursive-include tests *.py
 
 recursive-include utils *.py
@@ -26,7 +24,4 @@ recursive-include utils *.txt
 
 exclude .gitignore
 exclude .gitattributes
-recursive-exclude * __pycache__
-recursive-exclude *.pyc
-recursive-exclude .github *.yml
-recursive-exclude .github *.md
+prune .github

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,6 +59,3 @@ docs =
 fuzzer =
       atheris
       hypothesis
-
-[egg_info]
-egg_base = /tmp

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,3 +59,6 @@ docs =
 fuzzer =
       atheris
       hypothesis
+
+[egg_info]
+egg_base = /tmp


### PR DESCRIPTION
.egg-info is problematic in conda-forge recipe
https://github.com/conda-forge/staged-recipes/pull/15512

Signed-off-by: Hiroshi Miura <miurahr@linux.com>