### PR TITLE
Add tests where mem_size is less than file size

### DIFF
--- a/tests/test_ppmd8.py
+++ b/tests/test_ppmd8.py
@@ -1,6 +1,7 @@
 import hashlib
 import os
 import pathlib
+import pytest
 
 import pyppmd
 
@@ -44,13 +45,17 @@ def test_ppmd8_decoder2():
     assert decoder.eof
     assert result == source
 
-
-def test_ppmd8_encode_decode(tmp_path):
+# test mem_size less than original file size as well
+@pytest.mark.parametrize("mem_size",[
+    (8 << 20),
+    (1 << 20),
+])
+def test_ppmd8_encode_decode(tmp_path, mem_size):
     length = 0
     m = hashlib.sha256()
     with testdata_path.joinpath("10000SalesRecords.csv").open("rb") as f:
         with tmp_path.joinpath("target.ppmd").open("wb") as target:
-            enc = pyppmd.Ppmd8Encoder(6, 8 << 20)
+            enc = pyppmd.Ppmd8Encoder(6, mem_size)
             data = f.read(READ_BLOCKSIZE)
             while len(data) > 0:
                 m.update(data)
@@ -64,7 +69,7 @@ def test_ppmd8_encode_decode(tmp_path):
     length = 0
     with tmp_path.joinpath("target.ppmd").open("rb") as target:
         with tmp_path.joinpath("target.csv").open("wb") as out:
-            dec = pyppmd.Ppmd8Decoder(6, 8 << 20)
+            dec = pyppmd.Ppmd8Decoder(6, mem_size)
             data = target.read(READ_BLOCKSIZE)
             while len(data) > 0 or not dec.eof:
                 res = dec.decode(data)


### PR DESCRIPTION
It is important to test the situation where mem_size is less than the file size. So I added that test.

However, now `tests/test_ppmd8.py::test_ppmd8_encode_decode[1048576]` causes SIGFPE.

Increasing test_ppmd8.READ_BLOCKSIZE to `1<<18` is a workaround, but not sure if it ok or not. Could you take a look then merge this?

The resulting `target.ppmd` is the same among PPMD8_RESTORE_METHOD_RESTART and PPMD8_RESTORE_METHOD_CUT_OFF if not `mem_size is less than the file size`, so I do need to add this test. Sorry but #24 is blocked.