### PR TITLE
CI: test on Python 3.10.0, pypy-3.6 and pypy-3.7

### DIFF
--- a/.github/workflows/run-tox-tests.yml
+++ b/.github/workflows/run-tox-tests.yml
@@ -8,7 +8,15 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", pypy3]
+        python-version: [
+            "3.6",
+            "3.7",
+            "3.8",
+            "3.9",
+            "3.10",
+            "pypy-3.6",
+            "pypy-3.7",
+        ]
         exclude:
           - os: windows-latest
             python-version: pypy3

--- a/.github/workflows/run-tox-tests.yml
+++ b/.github/workflows/run-tox-tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10, pypy3]
         exclude:
           - os: windows-latest
             python-version: pypy3

--- a/.github/workflows/run-tox-tests.yml
+++ b/.github/workflows/run-tox-tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10, pypy3]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", pypy3]
         exclude:
           - os: windows-latest
             python-version: pypy3

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -7,6 +7,13 @@ All notable changes to this project will be documented in this file.
 `Unreleased`_
 =============
 
+`v0.17.2`_
+==========
+
+Fixed
+-----
+* Build on MingW/MSYS2(#68,#69)
+
 `v0.17.1`_
 ==========
 


### PR DESCRIPTION
Improve CI tox test to run on Python 3.10.0, pypy-3.6 and pypy-3.7.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>
