### PR TITLE
ppmd8: Add test case: fix it with a silent null

### DIFF
--- a/tests/test_fuzzer.py
+++ b/tests/test_fuzzer.py
@@ -23,7 +23,12 @@ def test_ppmd7_fuzzer(txt, max_order, mem_size):
     compressed += enc.flush()
     dec = pyppmd.Ppmd7Decoder(max_order=max_order, mem_size=mem_size)
     result = dec.decode(compressed, length)
-    result += dec.decode(b"", length - len(result))
+    if len(result) < length:
+        if dec.needs_input:
+            # ppmd need extra null byte
+            result += dec.decode(b"\0", length - len(result))
+        else:
+            result += dec.decode(b"", length - len(result))
     assert result == obj
 
 
@@ -42,7 +47,11 @@ def test_ppmd8_fuzzer(txt, max_order, mem_size):
     dec = pyppmd.Ppmd8Decoder(max_order=max_order, mem_size=mem_size, restore_method=pyppmd.PPMD8_RESTORE_METHOD_CUT_OFF)
     result = dec.decode(compressed, length)
     if len(result) < length:
-        result += dec.decode(b"", length)
+        if dec.needs_input:
+            # ppmd need extra null byte
+            result += dec.decode(b"\0", length - len(result))
+        else:
+            result += dec.decode(b"", length - len(result))
     assert result == obj
 
 

--- a/tests/test_ppmd7.py
+++ b/tests/test_ppmd7.py
@@ -32,7 +32,8 @@ def test_ppmd7_encoder2():
 def test_ppmd7_decoder():
     decoder = pyppmd.Ppmd7Decoder(6, 16 << 20)
     result = decoder.decode(encoded, 66)
-    result += decoder.decode(b"", 66 - len(result))
+    if len(result) < 66:
+        result += decoder.decode(b"\0", 66 - len(result))
     assert result == data
 
 
@@ -40,7 +41,8 @@ def test_ppmd7_decoder2():
     decoder = pyppmd.Ppmd7Decoder(6, 16 << 20)
     result = decoder.decode(encoded[:33], 33)
     result += decoder.decode(encoded[33:], 28)
-    result += decoder.decode(b"", 66 - len(result))
+    if len(result) < 66:
+        result += decoder.decode(b"\0", 66 - len(result))
     assert result == data
 
 
@@ -70,6 +72,10 @@ def test_ppmd7_encode_decode(tmp_path, mem_size):
                 data = target.read(READ_BLOCKSIZE)
                 res = dec.decode(data, min(remaining, READ_BLOCKSIZE))
                 if len(res) == 0:
+                    if dec.needs_input:
+                        res += dec.decode(b"\0", remaining)
+                    else:
+                        res += dec.decode(b"", remaining)
                     break
                 remaining -= len(res)
                 m2.update(res)
@@ -143,6 +149,10 @@ def test_ppmd7_decode_chunks():
                 data = f.read(READ_BLOCKSIZE)
                 out = dec.decode(data, remaining)
                 if len(out) == 0:
+                    if dec.needs_input:
+                        out += dec.decode(b"\0", remaining)
+                    else:
+                        out += dec.decode(b"", remaining)
                     break
                 remaining -= len(out)
                 result += out

--- a/tests/test_ppmd8.py
+++ b/tests/test_ppmd8.py
@@ -93,6 +93,20 @@ def test_ppmd8_encode_decode(tmp_path, mem_size, restore_method):
     assert thash == shash
 
 
+def test_ppmd8_encode_decode_shortage():
+    txt = "\U0001127f\U00069f6a\U00069f6a"
+    obj = txt.encode("UTF-8")
+    enc = pyppmd.Ppmd8Encoder(3, 2048)
+    data = enc.encode(obj)
+    data += enc.flush()
+    length = len(obj)
+    dec = pyppmd.Ppmd8Decoder(3, 2048)
+    res = dec.decode(data, length)
+    if len(res) < length:
+        res += dec.decode(b"\0", length - len(res))
+    assert obj == res
+
+
 def test_ppmdcompress():
     compressor = pyppmd.PpmdCompressor(6, 8 << 20, restore_method=pyppmd.PPMD8_RESTORE_METHOD_RESTART, variant="I")
     result = compressor.compress(source)


### PR DESCRIPTION
PPMd algorithm expect extra b"\0" byte when it requires input byte but all data is exhausted.
It can be observed as `inBuf.Extra` in p7zip project, both variation H and I.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>
