### PR TITLE
Fix 32bit test

### DIFF
--- a/tests/test_fuzzer.py
+++ b/tests/test_fuzzer.py
@@ -6,8 +6,10 @@ from hypothesis import strategies as st
 
 import pyppmd
 
-MAX_SIZE = 1 << 30
-
+if sys.maxsize > 2**32:
+    MAX_SIZE = 1 << 30
+else:
+    MAX_SIZE = 1 << 28
 
 @given(
     txt=st.text(min_size=1),

--- a/tests/test_fuzzer.py
+++ b/tests/test_fuzzer.py
@@ -11,6 +11,7 @@ if sys.maxsize > 2**32:
 else:
     MAX_SIZE = 1 << 28
 
+
 @given(
     txt=st.text(min_size=1),
     max_order=st.integers(min_value=2, max_value=64),


### PR DESCRIPTION
1GB is too big for 32bit machine, limiting to 256MB.

According to https://github.com/jinfeihan57/p7zip/blob/master/CPP/7zip/Compress/PpmdEncoder.cpp CEncProps::Normalize, 256MB is usual max (i.e. unless explicitly specified by complex option), so it should be ok.