### PR TITLE
 PPMd7: decode: fix eof/needs_input control

### DIFF
--- a/src/pyppmd/cffi/cffi_ppmd.py
+++ b/src/pyppmd/cffi/cffi_ppmd.py
@@ -441,6 +441,7 @@ class Ppmd7Decoder(PpmdBaseDecoder):
             self.inited = True
         out, out_buf = self._setup_outBuffer()
         remaining: int = length
+        out_size = 0
         while remaining > 0:
             size = min(out_buf.size, remaining)
             self.lock.release()
@@ -451,17 +452,17 @@ class Ppmd7Decoder(PpmdBaseDecoder):
                 raise PpmdError("DecodeError.")
             if out_size == -1 or self.rc.Code == 0:
                 self._eof = True
+                self._needs_input = False
+                break
+            if out_size == 0:
+                self._needs_input = True
                 break
             if out_buf.pos == out_buf.size:
                 out.grow(out_buf)
-            elif in_buf.pos == in_buf.size:
-                break
             remaining = remaining - out_size
         self._unconsumed_in(in_buf, use_input_buffer)
         res = out.finish(out_buf)
         self.lock.release()
-        if self._eof:
-            self._needs_input = False
         return res
 
     @property

--- a/tests/test_fuzzer.py
+++ b/tests/test_fuzzer.py
@@ -33,6 +33,8 @@ def test_ppmd7_fuzzer(txt, max_order, mem_size):
         else:
             result += dec.decode(b"", length - len(result))
     assert result == obj
+    assert dec.eof
+    assert not dec.needs_input
 
 
 @given(

--- a/tests/test_ppmd7.py
+++ b/tests/test_ppmd7.py
@@ -32,18 +32,25 @@ def test_ppmd7_encoder2():
 def test_ppmd7_decoder():
     decoder = pyppmd.Ppmd7Decoder(6, 16 << 20)
     result = decoder.decode(encoded, 66)
-    if len(result) < 66:
-        result += decoder.decode(b"\0", 66 - len(result))
     assert result == data
+    assert decoder.eof
+    assert not decoder.needs_input
 
 
 def test_ppmd7_decoder2():
     decoder = pyppmd.Ppmd7Decoder(6, 16 << 20)
     result = decoder.decode(encoded[:33], 33)
     result += decoder.decode(encoded[33:], 28)
-    if len(result) < 66:
-        result += decoder.decode(b"\0", 66 - len(result))
+    assert not decoder.eof
+    while len(result) < 66:
+        if decoder.needs_input:
+            result += decoder.decode(b"\0", 66 - len(result))
+            break
+        else:
+            result += decoder.decode(b"", 66 - len(result))
     assert result == data
+    assert not decoder.needs_input
+    assert decoder.eof
 
 
 # test mem_size less than original file size as well


### PR DESCRIPTION
And add `unused_data` getter method

Signed-off-by: Hiroshi Miura <miurahr@linux.com>
