### PR TITLE
Mingw: set env SETUPTOOLS_USE_DISTUTILS=stdlib

### DIFF
--- a/.github/workflows/run-tox-tests.yml
+++ b/.github/workflows/run-tox-tests.yml
@@ -90,7 +90,6 @@ jobs:
 
   test_on_msys2_mingw:
    name: Test on Mingw32/Windows
-   if: ${{ false }}
    runs-on: windows-2022
    defaults:
      run:
@@ -98,27 +97,21 @@ jobs:
    steps:
       - uses: msys2/setup-msys2@v2
         with:
-          update: true
+          update: false
           install: >-
-            base-devel
-            mingw-w64-x86_64-python
-            mingw-w64-x86_64-python-pip
-            mingw-w64-x86_64-gcc
             git
-      - name: Check python header
-        run: ls -l D:/a/_temp/msys64/mingw64/include/python*/Python.h
+            mingw-w64-x86_64-python-tox
+            mingw-w64-x86_64-python-setuptools-scm
+            mingw-w64-x86_64-gcc
       - name: Checkout 🛎️
         uses: actions/checkout@v3
         with:
           fetch-depth: 20
-      - name: Install python tox
-        run: |
-          pip install -U tox
       - name: Run test
         run: |
-          pip install -U tox
            python -m tox -e py39
         env:
+          SETUPTOOLS_USE_DISTUTILS: stdlib
           PYTEST_ADDOPTS: "--benchmark-skip"
 
   finish:
@@ -127,7 +120,6 @@ jobs:
     container: python:3-slim
     needs:
       - build
-      - test_on_aarch64
     steps:
       - name: Tell Coveralls that the parallel build is finished
         run: |

--- a/README.rst
+++ b/README.rst
@@ -61,9 +61,7 @@ You can do like as:
 WARNING
 -------
 
-* There is a known issues for Decoder that sometimes failed with access violation error
-  on 32bit python on Windows.
-* It is recommended to use PyPPMd on 64bit python.
+* When use it on MSYS2/MINGW64 environment, you should set environment variable ``SETUPTOOLS_USE_DISTUTILS=stdlib``
 
 Copyright and License
 ---------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ legacy_tox_ini = """
 envlist = check, py{36,37,38,39,310}, pypy3, docs, coveralls
 
 [testenv]
-passenv = TRAVIS TRAVIS_* APPVEYOR APPVEYOR_* GITHUB_* PYTEST_ADDOPTS COVERALLS_* MSYSTEM
+passenv = TRAVIS TRAVIS_* APPVEYOR APPVEYOR_* GITHUB_* PYTEST_ADDOPTS COVERALLS_* SETUPTOOLS_USE_DISTUTILS
 extras = test
 commands =
     python -m pytest -vv -s


### PR DESCRIPTION
setuptools v60 and later import distutils and change default to SETUPTOOLS_USE_DISTUTILS=local.
This cause setuptools don't use mingw's patched version of distutils and failed to build extensions.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>