### PR TITLE
Fix 'Build fails on aarch64-unknown-linux-android24'(#124)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ pytest-timeout
 cffi
 py-cpuinfo
 tox
+setuptools
 ")
 if (WIN32)
   set(PIP_COMMAND ${VENV_PATH}/Scripts/pip.exe)
@@ -147,6 +148,16 @@ add_custom_target(run_pytest
         COMMAND $<TARGET_FILE:pytest_runner> --verbose
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         DEPENDS pytest_runner)
+
+# ##################################################################################################
+# Some platform do not have `pthread_cancel`. We need to use `pthread_kill` on those platform.
+include(CheckSymbolExists)
+check_symbol_exists(pthread_cancel "pthread.h" HAVE_PTHREAD_CANCEL)
+if (NOT HAVE_PTHREAD_CANCEL)
+add_compile_definitions(PPMD_NO_PTHREAD_CANCEL=1)
+else()
+add_compile_definitions(PPMD_NO_PTHREAD_CANCEL=0)
+endif()
 
 # ##################################################################################################
 # for build test and analytics

--- a/src/lib/buffer/ThreadDecoder.c
+++ b/src/lib/buffer/ThreadDecoder.c
@@ -9,6 +9,12 @@
 #include <mach/mach.h>
 #endif
 
+#include <signal.h>
+
+#if defined(__ANDROID__) || defined(__BIONIC__) || defined(PPMD_NO_PTHREAD_CANCEL) || 1
+#define pthread_cancel(x) pthread_kill(x, SIGKILL)
+#endif
+
 #ifndef _MSC_VER
 int ppmd_timedwait(pthread_cond_t *cond, pthread_mutex_t *mutex, unsigned long nsec) {
     //https://gist.github.com/jbenet/1087739


### PR DESCRIPTION
Benchmark:

```text
--------------------------------------------------------------------------------------------- benchmark 'compress': 2 tests ----------------------------------------------------------------------------------------------
Name (time in ms)                                          Min                 Max                Mean             StdDev              Median                IQR            Outliers     OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_benchmark_text_compress[PPMd H-7-6-16777216]     208.6208 (1.0)      277.4195 (1.0)      235.8811 (1.0)      28.3367 (1.0)      231.3216 (1.0)      44.7625 (1.0)           1;0  4.2394 (1.0)           5           1
test_benchmark_text_compress[PPMd I-8-8-8388608]      244.2492 (1.17)     362.0023 (1.30)     287.4594 (1.22)     49.3901 (1.74)     263.8437 (1.14)     73.7615 (1.65)          1;0  3.4788 (0.82)          5           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

---------------------------------------------------------------------------------------------- benchmark 'decompress': 2 tests -----------------------------------------------------------------------------------------------
Name (time in ms)                                            Min                 Max                Mean              StdDev              Median                 IQR            Outliers     OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_benchmark_text_decompress[PPMd H-7-6-16777216]     185.6872 (1.0)      367.2979 (1.0)      244.0532 (1.0)       77.8981 (1.0)      197.9793 (1.0)      107.0395 (1.0)           1;0  4.0975 (1.0)           5           1
test_benchmark_text_decompress[PPMd I-8-8-8388608]      189.5612 (1.02)     522.2300 (1.42)     303.9971 (1.25)     129.2388 (1.66)     285.4922 (1.44)     131.8851 (1.23)          1;0  3.2895 (0.80)          5           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```