### PR TITLE
Ppmd7/Ppmd8: Fix SIGABRT in OutputBuffer_Grow

### DIFF
--- a/src/ext/_ppmdmodule.c
+++ b/src/ext/_ppmdmodule.c
@@ -531,6 +531,12 @@ Ppmd7Decoder_decode(Ppmd7Decoder *self,  PyObject *args, PyObject *kwargs) {
             break;
         }
         if (out->pos == out->size) {
+            /* Already reached max_length for this call; stop instead of
+               growing (avoids rest<=0 assert in OutputBuffer_Grow) */
+            if (self->blocksOutputBuffer->max_length >= 0 &&
+                self->blocksOutputBuffer->allocated >= self->blocksOutputBuffer->max_length) {
+                break;
+            }
             if (OutputBuffer_Grow(self->blocksOutputBuffer, out) < 0) {
                 PyErr_SetString(PyExc_ValueError, "No Memory.");
                 goto error;
@@ -1276,6 +1282,11 @@ Ppmd8Decoder_decode(Ppmd8Decoder *self,  PyObject *args, PyObject *kwargs) {
              break;  // filled expected
         }
         if (out->pos == out->size) {
+            /* Same guard as for Ppmd7Decoder_decode() above */
+            if (self->blocksOutputBuffer->max_length >= 0 &&
+                self->blocksOutputBuffer->allocated >= self->blocksOutputBuffer->max_length) {
+                break;
+            }
             if (OutputBuffer_Grow(self->blocksOutputBuffer, out) < 0) {
                 PyErr_SetString(PyExc_ValueError, "L1586: Unknown status");
                 goto error;
@@ -1302,6 +1313,11 @@ Ppmd8Decoder_decode(Ppmd8Decoder *self,  PyObject *args, PyObject *kwargs) {
             /* Clear input_buffer */
             self->in_begin = 0;
             self->in_end = 0;
+        }
+        if (self->eof) {
+            self->needs_input = False;
+        } else {
+            self->needs_input = True;
         }
     } else {
         const size_t data_size = in->size - in->pos;


### PR DESCRIPTION
The decode loop could abort in `OutputBuffer_Grow()` when a resumed decode thread wrote past the current call's `max_length`. Stop early once that limit is reached instead of trying to grow the buffer further.

Fixes `test_ppmd7_decode_chunks` and the equivalent Ppmd8 case, which previously aborted deterministically partway through decoding testdata2.ppmd in small chunks.

This work was sponsored by GOVCERT.LU.

I've noticed this issue while integrating the tests in the Yocto/OpenEmbedded layer meta-openembedded/meta-python. Without this fix test `test_ppmd7_decode_chunks` was crashing on Raspberry Pi 5:

```
PASS: tests/test_ppmd7.py:test_ppmd7_encode_decode[16777216]
PASS: tests/test_ppmd7.py:test_ppmd7_encode_decode[1048576]
Fatal Python error: Aborted
Current thread 0x00007ffecfe08020 [python3] (most recent call first):
  File "/usr/lib/python3-pyppmd/ptest/tests/test_ppmd7.py", line 157 in test_ppmd7_decode_chunks
  File "/usr/lib/python3.14/site-packages/_pytest/python.py", line 167 in pytest_pyfunc_call
  File "/usr/lib/python3.14/site-packages/pluggy/_callers.py", line 121 in _multicall
  File "/usr/lib/python3.14/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/usr/lib/python3.14/site-packages/pluggy/_hooks.py", line 512 in __call__
  File "/usr/lib/python3.14/site-packages/_pytest/python.py", line 1707 in runtest
  File "/usr/lib/python3.14/site-packages/_pytest/runner.py", line 184 in pytest_runtest_call
  File "/usr/lib/python3.14/site-packages/pluggy/_callers.py", line 121 in _multicall
  File "/usr/lib/python3.14/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/usr/lib/python3.14/site-packages/pluggy/_hooks.py", line 512 in __call__
  File "/usr/lib/python3.14/site-packages/_pytest/runner.py", line 250 in <lambda>
  File "/usr/lib/python3.14/site-packages/_pytest/runner.py", line 361 in from_call
  File "/usr/lib/python3.14/site-packages/_pytest/runner.py", line 249 in call_and_report
  File "/usr/lib/python3.14/site-packages/_pytest/runner.py", line 139 in runtestprotocol
  File "/usr/lib/python3.14/site-packages/_pytest/runner.py", line 118 in pytest_runtest_protocol
  File "/usr/lib/python3.14/site-packages/pluggy/_callers.py", line 121 in _multicall
  File "/usr/lib/python3.14/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/usr/lib/python3.14/site-packages/pluggy/_hooks.py", line 512 in __call__
  File "/usr/lib/python3.14/site-packages/_pytest/main.py", line 408 in pytest_runtestloop
  File "/usr/lib/python3.14/site-packages/pluggy/_callers.py", line 121 in _multicall
  File "/usr/lib/python3.14/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/usr/lib/python3.14/site-packages/pluggy/_hooks.py", line 512 in __call__
  File "/usr/lib/python3.14/site-packages/_pytest/main.py", line 384 in _main
  File "/usr/lib/python3.14/site-packages/_pytest/main.py", line 330 in wrap_session
  File "/usr/lib/python3.14/site-packages/_pytest/main.py", line 377 in pytest_cmdline_main
  File "/usr/lib/python3.14/site-packages/pluggy/_callers.py", line 121 in _multicall
  File "/usr/lib/python3.14/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/usr/lib/python3.14/site-packages/pluggy/_hooks.py", line 512 in __call__
  File "/usr/lib/python3.14/site-packages/_pytest/config/__init__.py", line 229 in _main
  File "/usr/lib/python3.14/site-packages/_pytest/config/__init__.py", line 253 in _console_main
  File "/bin/pytest", line 8 in <module>

Current thread's C stack trace (most recent call first):
  Binary file "/usr/lib/libpython3.14.so.1.0", at _Py_DumpStack+0x4c [0x7ffed00bb91c]
  Binary file "/usr/lib/libpython3.14.so.1.0", at +0x2c0224 [0x7ffed00d0224]
  Binary file "linux-vdso.so.1", at __kernel_rt_sigreturn+0x0 [0x7ffed0480840]
  Binary file "/usr/lib/libc.so.6", at +0x8a228 [0x7ffecfcca228]
  Binary file "/usr/lib/libc.so.6", at gsignal+0x1c [0x7ffecfc7717c]
  Binary file "/usr/lib/libc.so.6", at abort+0x30 [0x7ffecfc62720]
  Binary file "/usr/lib/libc.so.6", at +0x7d7f4 [0x7ffecfcbd7f4]
  Binary file "/usr/lib/libc.so.6", at __assert_fail+0xb4 [0x7ffecfc709b4]
  Binary file "/usr/lib/python3.14/site-packages/pyppmd/c/_ppmd.cpython-314-aarch64-linux-gnu.so", at +0x4580 [0x7ffecc504580]
  Binary file "/usr/lib/python3.14/site-packages/pyppmd/c/_ppmd.cpython-314-aarch64-linux-gnu.so", at +0x4760 [0x7ffecc504760]
  Binary file "/usr/lib/libpython3.14.so.1.0", at +0xf8b9c [0x7ffecff08b9c]
  Binary file "/usr/lib/libpython3.14.so.1.0", at PyObject_Vectorcall+0x58 [0x7ffecfef9d9c]
  Binary file "/usr/lib/libpython3.14.so.1.0", at _PyEval_EvalFrameDefault+0x2f28 [0x7ffed002bf98]
  Binary file "/usr/lib/libpython3.14.so.1.0", at +0x2274f0 [0x7ffed00374f0]
  Binary file "/usr/lib/libpython3.14.so.1.0", at +0xebbe8 [0x7ffecfefbbe8]
  Binary file "/usr/lib/libpython3.14.so.1.0", at +0xebde4 [0x7ffecfefbde4]
  Binary file "/usr/lib/libpython3.14.so.1.0", at +0x17c960 [0x7ffecff8c960]
  Binary file "/usr/lib/libpython3.14.so.1.0", at _PyObject_MakeTpCall+0xac [0x7ffecfef9af4]
  Binary file "/usr/lib/libpython3.14.so.1.0", at _PyEval_EvalFrameDefault+0x27c0 [0x7ffed002b830]
  Binary file "/usr/lib/libpython3.14.so.1.0", at +0x2274f0 [0x7ffed00374f0]
  Binary file "/usr/lib/libpython3.14.so.1.0", at +0xebbe8 [0x7ffecfefbbe8]
  Binary file "/usr/lib/libpython3.14.so.1.0", at +0xebde4 [0x7ffecfefbde4]
  Binary file "/usr/lib/libpython3.14.so.1.0", at +0x17c960 [0x7ffecff8c960]
  Binary file "/usr/lib/libpython3.14.so.1.0", at +0xec084 [0x7ffecfefc084]
  Binary file "/usr/lib/libpython3.14.so.1.0", at _PyEval_EvalFrameDefault+0x3774 [0x7ffed002c7e4]
  Binary file "/usr/lib/libpython3.14.so.1.0", at +0x2274f0 [0x7ffed00374f0]
  Binary file "/usr/lib/libpython3.14.so.1.0", at +0xebbe8 [0x7ffecfefbbe8]
  Binary file "/usr/lib/libpython3.14.so.1.0", at +0xebde4 [0x7ffecfefbde4]
  Binary file "/usr/lib/libpython3.14.so.1.0", at +0x17c960 [0x7ffecff8c960]
  Binary file "/usr/lib/libpython3.14.so.1.0", at _PyObject_MakeTpCall+0xac [0x7ffecfef9af4]
  Binary file "/usr/lib/libpython3.14.so.1.0", at _PyEval_EvalFrameDefault+0x27c0 [0x7ffed002b830]
  Binary file "/usr/lib/libpython3.14.so.1.0", at +0x2274f0 [0x7ffed00374f0]
  <truncated rest of calls>
Extension modules: pyppmd.c._ppmd (total: 1)
/usr/lib/python3-pyppmd/ptest/run-ptest: line 3:  1463 Aborted                    (core dumped) pytest --automake
```